### PR TITLE
Fix for building (avoid implicit-function-declaration Werror)

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,7 +13,7 @@ LOCAL_FORCE_STATIC_EXECUTABLE := true
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_UNSTRIPPED_PATH := $(TARGET_OUT_EXECUTABLES_UNSTRIPPED)
 
-LOCAL_CFLAGS := -DDEBUG_KMSG
+LOCAL_CFLAGS := -DDEBUG_KMSG -Wno-error=implicit-function-declaration
 LOCAL_STATIC_LIBRARIES := libc libcutils
 
 include $(BUILD_EXECUTABLE)
@@ -39,7 +39,7 @@ LOCAL_MODULE_STEM := bbootimg
 
 LOCAL_SRC_FILES:= src/bbootimg.c src/libbootimg.c
 
-LOCAL_CFLAGS := -DDEBUG_KMSG
+LOCAL_CFLAGS := -DDEBUG_KMSG -Wno-error=implicit-function-declaration
 LOCAL_SHARED_LIBRARIES := libc libcutils
 
 include $(BUILD_EXECUTABLE)
@@ -51,6 +51,6 @@ LOCAL_SRC_FILES := src/libbootimg.c
 LOCAL_MODULE := libbootimg
 LOCAL_MODULE_TAGS := eng
 
-LOCAL_CFLAGS := -DDEBUG_KMSG
+LOCAL_CFLAGS := -DDEBUG_KMSG -Wno-error=implicit-function-declaration
 
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
Added -Wno-error=implicit-function-declaration param to LOCAL_CFLAGS to avoid some build errors under some environments.